### PR TITLE
🔧 fix(ch04/access-log): resolve dependency error

### DIFF
--- a/ch04/exercises/access-log/src/package.json
+++ b/ch04/exercises/access-log/src/package.json
@@ -5,7 +5,8 @@
     "author": "Elton Stoneman",
     "dependencies": {
       "restify":"8.3.3",
-      "winston": "3.2.1"
+      "winston": "3.2.1",
+      "winston-transport": "4.3.0"
     }
   }
   


### PR DESCRIPTION
참고: https://github.com/sixeyed/diamol/issues/69 

의존성 버전이슈로 예제 4-3 스크립트가 정상적으로 작동하지 않습니다. package.json 파일의 dependencies에 `"winston-transport": "4.3.0"`을 추가한 결과 정상적으로 실습 진행할 수 있게 되어 PR 올립니다.